### PR TITLE
feat(DailyTracker): ui redesign

### DIFF
--- a/src/components/DailyTracker.jsx
+++ b/src/components/DailyTracker.jsx
@@ -702,6 +702,12 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
       return;
     }
 
+    // Prevent continuing if Pomodoro is running
+    if (pomodoroIsRunning) {
+      warning('Cannot continue timer while Pomodoro is active');
+      return;
+    }
+
     // Stop any active entry first
     if (activeEntry) {
       handleStop();
@@ -1491,7 +1497,13 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
                     <div className="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-all">
                       <button
                         onClick={() => handleContinue(entry)}
-                        className="bg-green-600 hover:bg-green-700 text-white p-3 rounded-full flex items-center space-x-1"
+                        disabled={pomodoroIsRunning}
+                        className={`p-3 rounded-full flex items-center space-x-1 transition-colors ${
+                          pomodoroIsRunning
+                            ? 'bg-gray-400 text-gray-200 cursor-not-allowed'
+                            : 'bg-green-600 hover:bg-green-700 text-white'
+                        }`}
+                        title={pomodoroIsRunning ? 'Cannot continue timer while Pomodoro is active' : ''}
                       >
                         <Play className="w-4 h-4" />
                       </button>

--- a/src/components/DailyTracker.jsx
+++ b/src/components/DailyTracker.jsx
@@ -1288,7 +1288,7 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
               <button
                 onClick={handleStart}
                 disabled={pomodoroIsRunning}
-                className={`px-6 py-3 rounded-lg font-semibold flex items-center space-x-2 transition-colors ${
+                className={`p-3 rounded-full font-semibold flex items-center space-x-2 transition-colors ${
                   pomodoroIsRunning
                     ? 'bg-gray-400 text-gray-200 cursor-not-allowed'
                     : activeEntry
@@ -1298,24 +1298,17 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
                 title={pomodoroIsRunning ? 'Cannot start timer while Pomodoro is active' : ''}
               >
                 {activeEntry ? (
-                  <>
-                    <Plus className="w-5 h-5" />
-                    <span>New</span>
-                  </>
+                  <Plus className="w-5 h-5" />
                 ) : (
-                  <>
-                    <Plus className="w-5 h-5" />
-                    <span>Start</span>
-                  </>
+                    <Play className="w-5 h-5" />
                 )}
               </button>
               {activeEntry && (
                 <button
                   onClick={handleStop}
-                  className="px-6 py-3 rounded-lg font-semibold flex items-center space-x-2 bg-red-600 hover:bg-red-700 text-white transition-colors"
+                  className="p-3 rounded-lg font-semibold flex items-center space-x-2 bg-red-600 hover:bg-red-700 text-white transition-colors"
                 >
                   <Square className="w-5 h-5" />
-                  <span>Stop</span>
                 </button>
               )}
             </div>
@@ -1407,10 +1400,9 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
                   <div className="opacity-0 group-hover:opacity-100 transition-all">
                     <button
                       onClick={handleStop}
-                      className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-lg flex items-center space-x-2"
+                      className="bg-red-600 hover:bg-red-700 text-white p-3 rounded-lg flex items-center space-x-2"
                     >
                       <Pause className="w-4 h-4" />
-                      <span>Pause</span>
                     </button>
                   </div>
                   {!isToday() && (
@@ -1499,17 +1491,15 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
                     <div className="flex items-center space-x-2 opacity-0 group-hover:opacity-100 transition-all">
                       <button
                         onClick={() => handleContinue(entry)}
-                        className="bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded-lg flex items-center space-x-1"
+                        className="bg-green-600 hover:bg-green-700 text-white p-3 rounded-full flex items-center space-x-1"
                       >
                         <Play className="w-4 h-4" />
-                        <span>Continue</span>
                       </button>
                       <button
                         onClick={() => handleOpenModal('edit', entry)}
-                        className="bg-blue-600 hover:bg-blue-700 text-white px-3 py-2 rounded-lg flex items-center space-x-1"
+                        className="bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-lg flex items-center space-x-1"
                       >
                         <Edit className="w-4 h-4" />
-                        <span>Edit</span>
                       </button>
                       {getDuplicateCount(entry.description) > 1 && (
                         <button

--- a/src/components/DailyTracker.jsx
+++ b/src/components/DailyTracker.jsx
@@ -1505,12 +1505,14 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
                             : 'bg-green-600 hover:bg-green-700 text-white'
                         }`}
                         title={pomodoroIsRunning ? 'Cannot continue timer while Pomodoro is active' : ''}
+                        aria-label={pomodoroIsRunning ? 'Cannot continue timer while Pomodoro is active' : `Continue task: ${entry.description}`}
                       >
                         <Play className="w-4 h-4" />
                       </button>
                       <button
                         onClick={() => handleOpenModal('edit', entry)}
                         className="bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-lg flex items-center space-x-1"
+                        aria-label={`Edit task: ${entry.description}`}
                       >
                         <Edit className="w-4 h-4" />
                       </button>

--- a/src/components/DailyTracker.jsx
+++ b/src/components/DailyTracker.jsx
@@ -1407,6 +1407,7 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
                     <button
                       onClick={handleStop}
                       className="bg-red-600 hover:bg-red-700 text-white p-3 rounded-lg flex items-center space-x-2"
+                      aria-label="Pause timer"
                     >
                       <Pause className="w-4 h-4" />
                     </button>

--- a/src/components/PomodoroTimer.jsx
+++ b/src/components/PomodoroTimer.jsx
@@ -143,6 +143,7 @@ const PomodoroTimer = () => {
                 onClick={() => setShowSettings(!showSettings)}
                 className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
                 title="Timer Settings"
+                aria-label="Timer settings"
               >
                 <SettingsIcon className="w-5 h-5" />
               </button>

--- a/src/components/PomodoroTimer.jsx
+++ b/src/components/PomodoroTimer.jsx
@@ -136,7 +136,7 @@ const PomodoroTimer = () => {
           <div className="flex items-center justify-between mb-4">
             <div className="flex-1">
               <h1 className="text-3xl font-bold text-gray-900">Pomodoro Timer</h1>
-              <p className="text-gray-600 mt-2">Stay focused with time management technique</p>
+              <p className="text-gray-600 mt-2">Boost productivity with focused work sessions</p>
             </div>
             <div className="flex items-center space-x-2">
               <button

--- a/src/components/PomodoroTimer.jsx
+++ b/src/components/PomodoroTimer.jsx
@@ -129,26 +129,33 @@ const PomodoroTimer = () => {
   const progress = ((totalTime - timeLeft) / totalTime) * 100;
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
-      <div className="bg-white rounded-lg shadow-lg p-8">
+    <div className="min-h-screen bg-gray-100 text-gray-900 p-6">
+      <div className="max-w-4xl mx-auto">
         {/* Header */}
-        <div className="flex items-center justify-between mb-8">
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900">Pomodoro Timer</h1>
-            <p className="text-gray-600 mt-2">Stay focused with time management technique</p>
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-4">
+            <div className="flex-1">
+              <h1 className="text-3xl font-bold text-gray-900">Pomodoro Timer</h1>
+              <p className="text-gray-600 mt-2">Stay focused with time management technique</p>
+            </div>
+            <div className="flex items-center space-x-2">
+              <button
+                onClick={() => setShowSettings(!showSettings)}
+                className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
+                title="Timer Settings"
+              >
+                <SettingsIcon className="w-5 h-5" />
+              </button>
+            </div>
           </div>
-          <button
-            onClick={() => setShowSettings(!showSettings)}
-            className="p-2 text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"
-          >
-            <SettingsIcon className="w-5 h-5" />
-          </button>
         </div>
+
+        <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
 
         {/* Settings Panel */}
         {showSettings && (
-          <div className="mb-8 p-6 bg-gray-50 rounded-lg">
-            <h3 className="text-lg font-semibold mb-4">Timer Settings</h3>
+          <div className="mb-6 p-4 bg-gray-50 rounded-lg border border-gray-200">
+            <h3 className="text-lg font-semibold mb-4 text-gray-900">Timer Settings</h3>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
                 <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -232,13 +239,13 @@ const PomodoroTimer = () => {
 
         {/* Task Input */}
         {!isTrackingTask && (
-            <div className="mb-8">
+            <div className="mb-6">
             <input
                 type="text"
                 value={currentTask}
                 onChange={(e) => setCurrentTask(e.target.value)}
                 placeholder="What are you working on?"
-                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 disabled={isRunning}
             />
             </div>
@@ -246,7 +253,7 @@ const PomodoroTimer = () => {
 
         {/* Status Information */}
         {isTrackingTask && (
-          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-8">
+          <div className="bg-blue-50 border border-blue-200 rounded-lg p-4 mb-6">
             <div className="flex items-center space-x-2 text-blue-800">
               <Timer className="w-5 h-5" />
               <span className="font-medium">Tracking time for: {currentTask}</span>
@@ -255,7 +262,7 @@ const PomodoroTimer = () => {
         )}
 {isTrackingTask && (
 <>
-        <div className="text-center mb-8">
+        <div className="text-center mb-6">
           <div className={`inline-flex items-center justify-center w-32 h-32 rounded-full ${getPhaseColor()} text-white mb-4`}>
             {getPhaseIcon()}
           </div>
@@ -272,7 +279,7 @@ const PomodoroTimer = () => {
         </div>
 
 
-        <div className="mb-8">
+        <div className="mb-6">
           <div className="w-full bg-gray-200 rounded-full h-2">
             <div 
               className={`h-2 rounded-full transition-all duration-1000 ${getPhaseColor()}`}
@@ -334,6 +341,7 @@ const PomodoroTimer = () => {
           >
             <span>Reset All</span>
           </button>
+        </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request updates both the `DailyTracker` and `PomodoroTimer` components to improve their interaction, enforce Pomodoro session exclusivity, and refine the UI for a more modern and consistent look. The most important changes are grouped below:

**Pomodoro and Timer Interaction Improvements:**

* Prevented starting or continuing a time entry in `DailyTracker` while a Pomodoro session is active, displaying a warning and disabling relevant buttons. This ensures users can't accidentally overlap Pomodoro and manual tracking. [[1]](diffhunk://#diff-df751083e05bd7709d1bab96744c99c3190232a443a38e346493bcc86a2d64b5R705-R710) [[2]](diffhunk://#diff-df751083e05bd7709d1bab96744c99c3190232a443a38e346493bcc86a2d64b5L1502-L1512)
* Updated button tooltips and disabled states to clearly communicate when actions are blocked due to an active Pomodoro.

**UI and Usability Enhancements:**

* Restyled various buttons in `DailyTracker` for a more modern, rounded appearance and consistent sizing, and simplified button content by removing text labels in favor of icon-only buttons. [[1]](diffhunk://#diff-df751083e05bd7709d1bab96744c99c3190232a443a38e346493bcc86a2d64b5L1291-R1297) [[2]](diffhunk://#diff-df751083e05bd7709d1bab96744c99c3190232a443a38e346493bcc86a2d64b5L1301-L1318) [[3]](diffhunk://#diff-df751083e05bd7709d1bab96744c99c3190232a443a38e346493bcc86a2d64b5L1410-L1413) [[4]](diffhunk://#diff-df751083e05bd7709d1bab96744c99c3190232a443a38e346493bcc86a2d64b5L1502-L1512)
* Refactored the `PomodoroTimer` layout for improved readability and visual hierarchy: added a background, adjusted panel paddings, and enhanced section separation.
* Updated input and status section spacing and styling in `PomodoroTimer` for better focus and clarity, including improved focus states and more consistent margins. [[1]](diffhunk://#diff-a0f4569324c37497af8ca916bfd0d845449fbec65c13dd1f68591faf2e2b8745L235-R256) [[2]](diffhunk://#diff-a0f4569324c37497af8ca916bfd0d845449fbec65c13dd1f68591faf2e2b8745L258-R265) [[3]](diffhunk://#diff-a0f4569324c37497af8ca916bfd0d845449fbec65c13dd1f68591faf2e2b8745L275-R282) [[4]](diffhunk://#diff-a0f4569324c37497af8ca916bfd0d845449fbec65c13dd1f68591faf2e2b8745R347)