### PR TITLE
feat: task input field is always cleared after entry

### DIFF
--- a/src/components/DailyTracker.jsx
+++ b/src/components/DailyTracker.jsx
@@ -625,10 +625,8 @@ const DailyTracker = ({ timezone, onTimezoneChange, onWeeklyTimesheetSave = () =
       const sortedEntries = [...allData[storageKey]].sort((a, b) => new Date(a.startTime) - new Date(b.startTime));
       setSelectedDateEntries(sortedEntries);
     }
-    // Only clear input if it was empty (using funny default)
-    if (!currentTask.trim()) {
-      setCurrentTask('');
-    }
+    // Clear input ready for the next task
+    setCurrentTask('');
   };
 
   // Stop active timer


### PR DESCRIPTION
This pull request makes a small adjustment to the `DailyTracker` component to improve user experience. Now, the task input field is always cleared after saving a timesheet entry, regardless of whether the input was empty or not, making it ready for the next task.