### PR TITLE
fix: fix InvalidStateError when clicking email field in invoice generator

### DIFF
--- a/src/components/InvoicePage.jsx
+++ b/src/components/InvoicePage.jsx
@@ -41,11 +41,16 @@ const EditableField = ({ label, value, placeholder, onChange, onFocus, onBlur, m
   const [editing, setEditing] = useState(false);
   const fieldRef = useRef(null);
 
+  const SELECTABLE_TYPES = ['text', 'search', 'url', 'tel', 'password'];
+
   useEffect(() => {
     if (editing && fieldRef.current) {
       fieldRef.current.focus();
-      const len = fieldRef.current.value.length;
-      fieldRef.current.setSelectionRange(len, len);
+      const field = fieldRef.current;
+      if (field.tagName === 'TEXTAREA' || SELECTABLE_TYPES.includes(field.type)) {
+        const len = field.value.length;
+        field.setSelectionRange(len, len);
+      }
     }
   }, [editing]);
 


### PR DESCRIPTION
setSelectionRange() was called unconditionally when an EditableField entered edit mode, but the browser only supports it on text, search, url, tel, password inputs, and textareas. Calling it on an input[type=email] threw InvalidStateError and left the field unclickable.

Guard the call to only run on selectable field types.